### PR TITLE
Fix startup hang

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -321,7 +321,7 @@ command.add(nil, {
 
 core.add_thread(function()
   while core.vibe.core_run_run==nil do
-    misc.sleep(1)
+    coroutine.yield(1)
   end
   core.log("vibe:wait_for_startup finished waiting")
   

--- a/vibeworkspace.lua
+++ b/vibeworkspace.lua
@@ -349,8 +349,7 @@ end
 command.add_hook("vibe:after-startup", function()
   if core.vibe.need_to_load_workspace then
     core.log("trying to load vibe workspace")
-    local temp = loadfile(vibeworkspace.savepath())
-    vibeworkspace.abs_filename = temp and temp()
+    vibeworkspace.abs_filename = vibeworkspace.savepath()
     core.log("abs_filename=%s", vibeworkspace.abs_filename)
 
     core.try(vibeworkspace.open_workspace_file)


### PR DESCRIPTION
`vibeworkspace.abs_filename` was being set to the result of the workspace file, which is `nil` in case it doesn't exist.
This resulted in the following `loadfile`
https://github.com/eugenpt/lite-xl-vibe/blob/575871aaff68ec581a7f3989bad7f5b67e0c9b17/vibeworkspace.lua#L318-L319
to be executed with a `nil` parameter, which hangs.